### PR TITLE
Brought DLI Adapter in line with the rest of the application

### DIFF
--- a/app/adapter.coffee
+++ b/app/adapter.coffee
@@ -45,6 +45,9 @@ getBook = (path) ->
   p
 
 
+getBookForDownload = (bookId) ->
+
+
 module.exports =
   toArray : toArray
   getBook : getBook

--- a/app/adapters/dli-adapter.coffee
+++ b/app/adapters/dli-adapter.coffee
@@ -48,7 +48,7 @@ getSizeInBytes = (metadata) -> -1
 getSubjects = (metadata) -> metadata.subjects or getValuesForPattern metadata, Pattern.subject
 
 
-getPublishers = (metadata) -> metadata.publishers or getValuesForPattern metadata, Pattern.publisher
+getPublisher = (metadata) -> metadata.publisher  #or getValuesForPattern metadata, Pattern.publisher
 
 
 getYear = (metadata) -> metadata.year
@@ -66,19 +66,20 @@ getBook = (path) ->
   p = new Promise (resolve, reject) ->
     handleDLIManifest = (manifestFileReadError, manifestFileContent) ->
       if manifestFileReadError
-        console.error manifestFileReadError
+        console.error 'Manifest file read error', manifestFileReadError
         reject manifestFileReadError
       else
         m = JSON.parse manifestFileContent
-        book = new $Book path, getTitle(m), getAuthors(m), getSizeInBytes(m), getYear(m), getSubjects(m), getPublishers(m), ADAPTER_ID
+        book = new $Book path, getTitle(m), getAuthors(m), getSizeInBytes(m), getYear(m), getSubjects(m), getPublisher(m), ADAPTER_ID
         resolve book
 
     handleStat = (statError, stat) ->
       if statError
+        console.error 'file stat error', statError
         reject statError
       else if not stat.isDirectory()
         logger.warn 'Not a directory'
-        reject null
+        resolve null
       else
         manifestFilePath = $Path.join(path, DLI_MANIFEST_FILE)
         $FS.exists manifestFilePath, (fileExists) ->
@@ -87,7 +88,7 @@ getBook = (path) ->
             $FS.readFile manifestFilePath, {encoding: 'utf8'}, handleDLIManifest
           else
             logger.warn 'No manifest file. Return null'
-            reject null
+            resolve null
 
     $FS.stat path, handleStat
   p

--- a/app/book.coffee
+++ b/app/book.coffee
@@ -13,9 +13,9 @@ Meant as a spec. Adapters may extend it.
 id : simply path for now.
 ###
 class Book
-  constructor: (@id, title, authors = [], @sizeInBytes, year = -1, subjects = [], publisher = '', @adapterId) ->
+  constructor: (@path, title, authors = [], @sizeInBytes, year = -1, subjects = [], publisher = '', @adapterId) ->
     # Numeric id for indexing.
-    @_id   = $Utils.getHash @id
+    @id   = $Utils.getHash @path
 
     # strings should always be lower case.
     @title      = title.toLowerCase()

--- a/app/db.coffee
+++ b/app/db.coffee
@@ -47,7 +47,7 @@ saveBook = (book) ->
 
     logger.debug 'run upsert'
     collectionBooks.update(
-      {_id: book._id},
+      {id: book.id},
       book,
       {upsert: true},
       handleUpsert


### PR DESCRIPTION
- DLI adapter no longer throws error when not identifying a path
- Book now stores the path explicitly as path. Creates id as hash from it. No more _id
